### PR TITLE
Allow autoloading of bundle with Doctrine

### DIFF
--- a/Transactions/Doctrine/DBALTransactionManager.php
+++ b/Transactions/Doctrine/DBALTransactionManager.php
@@ -22,7 +22,7 @@ use SimpleThings\TransactionalBundle\Transactions\TransactionManagerInterface;
  * 
  * @author Benjamin Eberlei
  */
-class DoctrineDBALTransactionManager implements TransactionManagerInterface
+class DBALTransactionManager implements TransactionManagerInterface
 {
     private $conn;
     


### PR DESCRIPTION
To work with the default Symfony2.1 autoloader, this class needs to have the same name as the file.
